### PR TITLE
Add server-side GraphQL proxy, secure env handling, and refactor queries/conditions

### DIFF
--- a/src/L1/resume/app/api/graphql/route.ts
+++ b/src/L1/resume/app/api/graphql/route.ts
@@ -10,15 +10,43 @@ function getHasuraConfig() {
   };
 }
 
+type GraphQLRequestBody = { query?: unknown };
+
+function hasQueryText(value: unknown): value is GraphQLRequestBody {
+  return typeof value === "object" && value !== null && "query" in value;
+}
+
+function getGraphQLOperationText(body: string) {
+  try {
+    const parsedBody = JSON.parse(body) as unknown;
+
+    if (Array.isArray(parsedBody)) {
+      return parsedBody
+        .filter(hasQueryText)
+        .map((requestBody) => requestBody.query)
+        .filter((query): query is string => typeof query === "string")
+        .join("\n");
+    }
+
+    if (hasQueryText(parsedBody) && typeof parsedBody.query === "string") {
+      return parsedBody.query;
+    }
+  } catch {
+    return body;
+  }
+
+  return body;
+}
+
 function isReadOnlyGraphQLRequest(body: string) {
-  const normalizedBody = body.toLowerCase();
+  const normalizedOperationText = getGraphQLOperationText(body).toLowerCase();
 
   return ![
     "mutation",
     "subscription",
     "__schema",
     "__type",
-  ].some((blockedToken) => normalizedBody.includes(blockedToken));
+  ].some((blockedToken) => normalizedOperationText.includes(blockedToken));
 }
 
 export async function POST(request: Request) {

--- a/src/L1/resume/app/components/DimensionItemInfo.container.tsx
+++ b/src/L1/resume/app/components/DimensionItemInfo.container.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, ReactNode, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_ITEMS } from "@/lib/queries";
@@ -18,23 +20,25 @@ export function DimensionItemInfoContainer({
   isOpen,
   onToggle,
 }: DimensionItemInfoContainerProps) {
-  const resource_name =
+  const resourceName =
     kind === "dimension"
       ? "DIMENSION_ITEM"
       : kind === "region"
       ? "REGION_ITEM"
-      : "";
+      : "DIMENSION_ITEM";
+  const shouldSkipQuery = !isOpen || (kind !== "dimension" && kind !== "region");
+  const itemRequest = GET_ITEMS(resourceName, name);
 
   const { data, loading, error, refetch } = useQuery(
-    GET_ITEMS(resource_name, name),
-    { skip: !isOpen }
+    itemRequest.query,
+    { variables: itemRequest.variables, skip: shouldSkipQuery }
   );
 
   useEffect(() => {
-    if (isOpen) {
+    if (!shouldSkipQuery) {
       refetch();
     }
-  }, [isOpen]);
+  }, [shouldSkipQuery, refetch]);
 
   return (
     <span>TEST</span>

--- a/src/L1/resume/app/components/DimensionItemInfo.tsx
+++ b/src/L1/resume/app/components/DimensionItemInfo.tsx
@@ -26,13 +26,13 @@ export function DimensionItemInfo({
 }: DimensionItemInfoProps) {
   // ポータルのためにドキュメントのルートにレンダリング
 
-  const resource_name: string = kind === "dimension" ? "DIMENSION_ITEM" : kind === "region" ? "REGION_ITEM" : "";
-  // const resource_name: string = kind === "dimension" ? "DIMENSION_ITEM" : "";
+  const resourceName = kind === "dimension" ? "DIMENSION_ITEM" : kind === "region" ? "REGION_ITEM" : "DIMENSION_ITEM";
+  const shouldSkipQuery = !isOpen || (kind !== "dimension" && kind !== "region");
+  const itemRequest = GET_ITEMS(resourceName, name);
 
-  // console.log(GET_ITEMS(resource_name, name))
-
-  const { data, loading, error, refetch } = useQuery(GET_ITEMS(resource_name, name), {
-    skip: !isOpen,  // 初回ロード時にクエリをスキップする
+  const { data, loading, error, refetch } = useQuery(itemRequest.query, {
+    variables: itemRequest.variables,
+    skip: shouldSkipQuery,  // 初回ロード時にクエリをスキップする
     // onCompleted: (data) => {
     //   console.log("データ取得成功:", data); // クエリ成功時のデータをログ出力
     // },
@@ -43,10 +43,10 @@ export function DimensionItemInfo({
 
   
   useEffect(() => {
-    if (isOpen) {
+    if (!shouldSkipQuery) {
       refetch();
     }  
-  }, [isOpen]);
+  }, [shouldSkipQuery, refetch]);
 
   return (
     <Drawer
@@ -60,12 +60,12 @@ export function DimensionItemInfo({
             <span className="loading loading-spinner text-primary">読み込み中です</span>
           ) : error instanceof Error ? (
             <p>Error: {error.message}</p>
-          ) : data && data.item ? (
+          ) : data && data.items ? (
             <>
               <div className="divider divider-start divider-primary text-xl">項目一覧</div>
               <div className="flex flex-row flex-wrap gap-2">
                 {
-                  data.item.map((item: {name: string}) => (
+                  data.items.map((item: {name: string}) => (
                     <div key={item.name} className="btn btn-outline"><LuComponent/>{item.name}</div>
                   ))
                 }

--- a/src/L1/resume/app/components/Dropdown.container.tsx
+++ b/src/L1/resume/app/components/Dropdown.container.tsx
@@ -53,9 +53,8 @@ export function DropdownContainer({ kind, name }: DropdownContainerProps)  {
 
     try {
       const searchQuery = GET_ITEMS("DIMENSION_ITEM", word);
-      const query = searchQuery;
 
-      const { data } = await client.query({query})
+      const { data } = await client.query(searchQuery)
       const items: DimensionItem[] = data.items.map((item: {name: string;}, index:number) => ({
         id: String(index + 1), // IDを文字列化
         name: item.name,

--- a/src/L1/resume/app/components/RegionSelector.container.tsx
+++ b/src/L1/resume/app/components/RegionSelector.container.tsx
@@ -45,10 +45,9 @@ export function RegionSelectorContainer() {
   const onSearch = async (word:string) => {
 
     try {
-      const searchQuery = GET_SEARCH_TAG_LIST(resource_name,resource_field, ref_names, word, items);
-      const query = searchQuery;
+      const searchQuery = GET_SEARCH_TAG_LIST(resource_name, resource_field, ref_names, word, items);
 
-      const { data } = await client.query({query})
+      const { data } = await client.query(searchQuery)
       setData(data)
 
     } catch (err) {

--- a/src/L1/resume/app/components/SearchItemSelector.tsx
+++ b/src/L1/resume/app/components/SearchItemSelector.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import React, { useState, useMemo } from 'react';
-import { gql } from '@apollo/client';
 import { createApolloClient } from '@/lib/apolloClient';
 import { GET_SEARCH_TAG_LIST } from '../../lib/queries';
 
@@ -44,14 +43,13 @@ export default function SearchItemSelector({ labelja, labelen = "", ref_names, r
   const client = createApolloClient();
 
 
-  const searchQuery = useMemo(() => GET_SEARCH_TAG_LIST(resource_name,resource_field, ref_names, searchTerm, items), [items, resource_field,searchTerm ]);
+  const searchQuery = useMemo(() => GET_SEARCH_TAG_LIST(resource_name, resource_field, ref_names, searchTerm, items), [items, resource_name, resource_field, ref_names, searchTerm]);
 
   const handleSearch = async () => {
     try {
        
 
-      const query = searchQuery;
-      const { data } = await client.query({query})
+      const { data } = await client.query(searchQuery)
       setData(data)
 
     } catch (err) {

--- a/src/L1/resume/app/components/SearchItems.tsx
+++ b/src/L1/resume/app/components/SearchItems.tsx
@@ -35,7 +35,13 @@ export default function SearchItems({ names }: SearchItemsProps) {
       <button className="btn btn-outline items-center ml-auto" onClick={handleClick}><GrGraphQl />graphQLを表示</button>
       <dialog id="view_graphQL" className="modal">
         <div className="modal-box whitespace-pre-wrap">
-        {print(searchQuery)}
+        {print(searchQuery.query)}
+          {searchQuery.variables && (
+            <>
+              {"\n\nVariables:\n"}
+              {JSON.stringify(searchQuery.variables, null, 2)}
+            </>
+          )}
         </div>
         <form method="dialog" className="modal-backdrop">
           <button>close</button>

--- a/src/L1/resume/app/contexts/SearchItemsContext.tsx
+++ b/src/L1/resume/app/contexts/SearchItemsContext.tsx
@@ -1,7 +1,7 @@
 "use client"; // このファイルはクライアントサイドでのみ実行される
 
-import { DocumentNode } from 'graphql';
-import React, { createContext, useState, ReactNode } from 'react';
+import type { GraphQLRequest } from '@/lib/queries';
+import { createContext } from 'react';
 
 
 // Contextの型定義
@@ -12,7 +12,7 @@ interface SearchItemContextType {
   addItem: (kind:string, itemName:string) => void;
   removeItem: (kind:string, itemName:string) => void;
 
-  searchQuery: DocumentNode;
+  searchQuery: GraphQLRequest;
 
   offset: number;
   setOffset: (offset:number) => void;

--- a/src/L1/resume/app/contexts/SearchItemsProvider.tsx
+++ b/src/L1/resume/app/contexts/SearchItemsProvider.tsx
@@ -2,7 +2,6 @@
 import React, { useContext, useState, ReactNode, useMemo, useEffect } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
-import { gql, useQuery } from "@apollo/client";
 import { createApolloClient } from "@/lib/apolloClient";
 
 import { SearchItemContext } from './SearchItemsContext';
@@ -128,8 +127,7 @@ export const SearchItemProvider = ({ children }: SearchItemProviderProps) => {
 
     try {
 
-      const query = countQuery;
-      const result = await client.query({ query });
+      const result = await client.query(countQuery);
 
       setCountResult(result.data.tablelist_aggregate.aggregate)
 
@@ -147,10 +145,13 @@ export const SearchItemProvider = ({ children }: SearchItemProviderProps) => {
 
     try {
 
-      const query = searchQuery;
       const result = await client.query({
-        query,
-        variables: { limit_number: limit, offset_number: offset },
+        ...searchQuery,
+        variables: {
+          ...searchQuery.variables,
+          limit_number: limit,
+          offset_number: offset,
+        },
       });
 
       if (result.data.tablelist.length != 0) {

--- a/src/L1/resume/lib/BuilderCondition.ts
+++ b/src/L1/resume/lib/BuilderCondition.ts
@@ -1,75 +1,105 @@
-import { UniqueOperationNamesRule } from "graphql";
+type GraphQLCondition = Record<string, unknown>;
 
+type EqualityConditionConfig = {
+  kind: string;
+  tableName: string;
+  columnName: string;
+};
 
-type Operator = "_eq" | "_gte" | "_lte";
+const equalityConditionConfigs: EqualityConditionConfig[] = [
+  { kind: "stat", tableName: "STATLIST", columnName: "STATNAME" },
+  { kind: "measure", tableName: "TABLE_MEASUREs", columnName: "NAME" },
+  { kind: "thema", tableName: "TABLE_TAGs", columnName: "TAG_NAME" },
+  { kind: "dimension", tableName: "TABLE_DIMENSIONs", columnName: "CLASS_NAME" },
+  { kind: "region", tableName: "TABLE_REGIONs", columnName: "NAME" },
+];
 
-function BuilderCondition_core(items: Map<string, Set<string>>, kind: string, table_name: string, column_name: string, operator: Operator = "_eq"): string {
+function buildEqualityConditions(
+  items: Map<string, Set<string>>,
+  { kind, tableName, columnName }: EqualityConditionConfig
+): GraphQLCondition[] {
+  const itemsOfKind = items.get(kind);
 
-    let condition: string = "";
-    if (items.has(kind)) {
-        const items_of_kind = items.get(kind)
-        if (items_of_kind && items_of_kind.size >= 1) {
-            const quotedItems = Array.from(items_of_kind).map(item => `${table_name}: { ${column_name}: {_eq: "${item}" } }`);
-            condition = quotedItems.join(",")
-        }
+  if (!itemsOfKind || itemsOfKind.size === 0) {
+    return [];
+  }
+
+  return Array.from(itemsOfKind).map((item) => ({
+    [tableName]: {
+      [columnName]: {
+        _eq: item,
+      },
+    },
+  }));
+}
+
+function buildTimeConditions(
+  items: Map<string, Set<string>>,
+  kind: string,
+  tableName: string,
+  columnName: string
+): GraphQLCondition[] {
+  const itemsOfKind = items.get(kind);
+
+  if (!itemsOfKind || itemsOfKind.size === 0) {
+    return [];
+  }
+
+  const conditions: GraphQLCondition[] = [];
+
+  for (const item of itemsOfKind) {
+    const [from, to] = item.split("-");
+    const yearCondition: Record<string, number> = {};
+
+    if (from !== "") {
+      const fromYear = Number(from);
+      if (!Number.isNaN(fromYear)) {
+        yearCondition._gte = fromYear;
+      }
     }
 
-    return (condition)
-
-}
-
-function BuilderTimeCondition(items: Map<string, Set<string>>, kind: string, table_name: string, column_name: string): string {
-
-    let condition: string = "";
-    if (items.has(kind)) {
-        const items_of_kind = items.get(kind)
-        if (items_of_kind && items_of_kind.size >= 1) {
-            const quotedItems = Array.from(items_of_kind).map(
-                item => {
-                    const [from, to] = item.split("-"); // "-" で分割
-                    
-                    const parts: string[] = [];
-                    if (from !== "") parts.push(`_gte: ${from}`);
-                    if (to !== "") parts.push(`_lte: ${to}`);
-
-                    if (parts.length === 0) {
-                        return ""; // 両方 undefined の場合は条件なし
-                    } else {
-                        return `${table_name}: { ${column_name}: { ${parts.join(", ")} } }`;
-                    }
-
-                });
-            condition = quotedItems.join(",")
-        }
+    if (to !== "") {
+      const toYear = Number(to);
+      if (!Number.isNaN(toYear)) {
+        yearCondition._lte = toYear;
+      }
     }
 
-    return (condition)
+    if (Object.keys(yearCondition).length > 0) {
+      conditions.push({
+        [tableName]: {
+          [columnName]: yearCondition,
+        },
+      });
+    }
+  }
 
+  return conditions;
 }
 
+function groupOrConditions(conditions: GraphQLCondition[]): GraphQLCondition | undefined {
+  if (conditions.length === 0) {
+    return undefined;
+  }
 
-export function BuilderCondition(items: Map<string, Set<string>>): string[] {
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
 
-    const statsCondition = BuilderCondition_core(items, "stat", "STATLIST", "STATNAME");
-    const measuresCondition = BuilderCondition_core(items, "measure", "TABLE_MEASUREs", "NAME");
-    const themasCondition = BuilderCondition_core(items, "thema", "TABLE_TAGs", "TAG_NAME");
-    const dimensionsCondition = BuilderCondition_core(items, "dimension", "TABLE_DIMENSIONs", "CLASS_NAME");
-    const regionsCondition = BuilderCondition_core(items, "region", "TABLE_REGIONs", "NAME");
-    const timeCondition = BuilderTimeCondition(items, "time", "TABLE_TIMEs", "YEAR");
-
-    const conditions = [
-        statsCondition,
-        measuresCondition,
-        themasCondition,
-        dimensionsCondition,
-        regionsCondition,
-        timeCondition
-    ].filter(condition => condition !== ""); // null でないものをフィルタリング
-
-    return (conditions)
-
-    // return([statsCondition, measuresCondition, themasCondition].join(" "))
-
+  return { _or: conditions };
 }
 
+export function BuilderCondition(items: Map<string, Set<string>>): GraphQLCondition {
+  const conditions = [
+    ...equalityConditionConfigs.map((config) =>
+      groupOrConditions(buildEqualityConditions(items, config))
+    ),
+    groupOrConditions(buildTimeConditions(items, "time", "TABLE_TIMEs", "YEAR")),
+  ].filter((condition): condition is GraphQLCondition => condition !== undefined);
 
+  if (conditions.length === 0) {
+    return {};
+  }
+
+  return { _and: conditions };
+}

--- a/src/L1/resume/lib/queries.ts
+++ b/src/L1/resume/lib/queries.ts
@@ -1,107 +1,174 @@
-
-import { gql, DocumentNode } from "@apollo/client";
+import { gql } from "@apollo/client";
+import type { DocumentNode } from "graphql";
 import { BuilderCondition } from "./BuilderCondition";
 
-export const GET_TABLE_LIST = (items: Map<string, Set<string>>): DocumentNode =>  {
-
-    // const searchCondition: string = `_and: [ ${BuilderCondition(items).join(",")} ]`;
-    const searchCondition: string = `${BuilderCondition(items).join(",")}`;
-
-    console.log("searchCondition:", searchCondition);
-
-    return(gql`
-        query GetTableList($limit_number: Int, $offset_number: Int) {
-            tablelist: TABLELIST(
-                where:{${searchCondition}}
-                limit: $limit_number
-                offset: $offset_number
-                order_by: { STATDISPID: asc }
-            ) {
-                statdispid: STATDISPID
-                cycle: CYCLE
-                statcode: STATCODE
-                survey_date: SURVEY_DATE
-                title: TITLE
-                year_s: YEAR_S
-                year_e: YEAR_E
-                table_tags: TABLE_TAGs {
-                    tag_name: TAG_NAME
-                }
-                table_measures: TABLE_MEASUREs {
-                    name: NAME
-                }
-                table_dimensions: TABLE_DIMENSIONs {
-                    class_name: CLASS_NAME
-                }
-                table_regions: TABLE_REGIONTYPEs {
-                    regiontype: REGIONTYPE
-                }
-            }
-        }
-    `)
-
+export interface GraphQLRequest {
+  query: DocumentNode;
+  variables?: Record<string, unknown>;
 }
 
-export const GET_TABLE_LIST_COUNT = (items: Map<string, Set<string>>): DocumentNode =>  {
+const tableListFields = gql`
+  fragment TableListFields on TABLELIST {
+    statdispid: STATDISPID
+    cycle: CYCLE
+    statcode: STATCODE
+    survey_date: SURVEY_DATE
+    title: TITLE
+    year_s: YEAR_S
+    year_e: YEAR_E
+    table_tags: TABLE_TAGs {
+      tag_name: TAG_NAME
+    }
+    table_measures: TABLE_MEASUREs {
+      name: NAME
+    }
+    table_dimensions: TABLE_DIMENSIONs {
+      class_name: CLASS_NAME
+    }
+    table_regions: TABLE_REGIONTYPEs {
+      regiontype: REGIONTYPE
+    }
+  }
+`;
 
-    const searchCondition: string = `${BuilderCondition(items).join(",")}`;
+export const GET_TABLE_LIST = (items: Map<string, Set<string>>): GraphQLRequest => ({
+  query: gql`
+    ${tableListFields}
+    query GetTableList(
+      $where: TABLELIST_bool_exp!
+      $limit_number: Int
+      $offset_number: Int
+    ) {
+      tablelist: TABLELIST(
+        where: $where
+        limit: $limit_number
+        offset: $offset_number
+        order_by: { STATDISPID: asc }
+      ) {
+        ...TableListFields
+      }
+    }
+  `,
+  variables: {
+    where: BuilderCondition(items),
+  },
+});
 
-    return(gql`
-        query GetTableList($limit_number: Int, $offset_number: Int) {
-            tablelist_aggregate: TABLELIST_aggregate(
-                where:{${searchCondition}}
-            ) {
-                aggregate {
-                    stat: count(distinct: true, column: STATCODE)
-                    db: count(distinct: true, column: STATDISPID)
-                }
-            }
+export const GET_TABLE_LIST_COUNT = (items: Map<string, Set<string>>): GraphQLRequest => ({
+  query: gql`
+    query GetTableListCount($where: TABLELIST_bool_exp!) {
+      tablelist_aggregate: TABLELIST_aggregate(where: $where) {
+        aggregate {
+          stat: count(distinct: true, column: STATCODE)
+          db: count(distinct: true, column: STATDISPID)
         }
-    `)
-}
+      }
+    }
+  `,
+  variables: {
+    where: BuilderCondition(items),
+  },
+});
 
+const getItemsQueries: Record<string, DocumentNode> = {
+  DIMENSION_ITEM: gql`
+    query GetDimensionItems($className: String!) {
+      items: DIMENSION_ITEM(where: { CLASS_NAME: { _eq: $className } }) {
+        name: NAME
+      }
+    }
+  `,
+  REGION_ITEM: gql`
+    query GetRegionItems($className: String!) {
+      items: REGION_ITEM(where: { CLASS_NAME: { _eq: $className } }) {
+        name: NAME
+      }
+    }
+  `,
+};
 
-export const GET_ITEMS = (resource_name: string, name: string): DocumentNode =>  {
+export const GET_ITEMS = (resourceName: string, name: string): GraphQLRequest => {
+  const query = getItemsQueries[resourceName];
 
-    return(gql`
-        query get_items {
-        items: ${resource_name}(where: {CLASS_NAME: {_eq: "${name}"}}) {
-            name: NAME
+  if (!query) {
+    throw new Error(`Unsupported item resource: ${resourceName}`);
+  }
+
+  return {
+    query,
+    variables: {
+      className: name,
+    },
+  };
+};
+
+const searchTagListQueries: Record<string, DocumentNode> = {
+  "STATLIST:STATNAME:TABLELISTs": gql`
+    query SearchStatList($tableWhere: TABLELIST_bool_exp!, $searchPattern: String!) {
+      items: STATLIST(
+        where: { TABLELISTs: $tableWhere, STATNAME: { _like: $searchPattern } }
+      ) {
+        name: STATNAME
+      }
+    }
+  `,
+  "MEASURELIST:NAME:TABLE_MEASUREs.TABLELIST": gql`
+    query SearchMeasureList($tableWhere: TABLELIST_bool_exp!, $searchPattern: String!) {
+      items: MEASURELIST(
+        where: {
+          TABLE_MEASUREs: { TABLELIST: $tableWhere }
+          NAME: { _like: $searchPattern }
         }
+      ) {
+        name: NAME
+      }
+    }
+  `,
+  "DIMENSIONLIST:CLASS_NAME:TABLE_DIMENSIONs.TABLELIST": gql`
+    query SearchDimensionList($tableWhere: TABLELIST_bool_exp!, $searchPattern: String!) {
+      items: DIMENSIONLIST(
+        where: {
+          TABLE_DIMENSIONs: { TABLELIST: $tableWhere }
+          CLASS_NAME: { _like: $searchPattern }
         }
-    `)
-}
-
-
-
-
+      ) {
+        name: CLASS_NAME
+      }
+    }
+  `,
+  "REGIONLIST:NAME:TABLE_REGIONs.TABLELIST": gql`
+    query SearchRegionList($tableWhere: TABLELIST_bool_exp!, $searchPattern: String!) {
+      items: REGIONLIST(
+        where: {
+          TABLE_REGIONs: { TABLELIST: $tableWhere }
+          NAME: { _like: $searchPattern }
+        }
+      ) {
+        name: NAME
+      }
+    }
+  `,
+};
 
 export const GET_SEARCH_TAG_LIST = (
-    name: string, 
-    field: string,
-    ref_names: string[],
-    searchTerm: string,
-    items: Map<string, Set<string>>
-    ): DocumentNode =>  {
+  name: string,
+  field: string,
+  refNames: string[],
+  searchTerm: string,
+  items: Map<string, Set<string>>
+): GraphQLRequest => {
+  const queryKey = `${name}:${field}:${refNames.join(".")}`;
+  const query = searchTagListQueries[queryKey];
 
-    const searchCondition: string = `${BuilderCondition(items).join(",")}`;
+  if (!query) {
+    throw new Error(`Unsupported search tag resource: ${queryKey}`);
+  }
 
-    const ref_name_s = ref_names.join(":{")
-    const ref_name_e = '}'.repeat(ref_names.length - 1);
-
-    const test_query = `
-        query GetMetaData {
-            items: ${name}(where: {
-                ${ref_name_s}: { ${searchCondition} } ${ref_name_e}
-                ${field}: { _like: "%${searchTerm}%" }
-                })
-                {
-                    name: ${field}
-                }
-            }
-    `;
-
-    console.log(test_query)
-    return(gql`${test_query}`)
-
-}
+  return {
+    query,
+    variables: {
+      tableWhere: BuilderCondition(items),
+      searchPattern: `%${searchTerm}%`,
+    },
+  };
+};


### PR DESCRIPTION
### Motivation
- Prevent exposing Hasura admin secret to the browser and enforce read-only client queries by proxying GraphQL through a Next.js API route.
- Replace string-built GraphQL queries and where-clause concatenation with typed query objects and variables for safer, clearer query construction.
- Improve environment configuration and developer README to document server-only variables and usage.

### Description
- Add a server GraphQL proxy at `app/api/graphql/route.ts` that forwards requests to Hasura with `HASURA_ADMIN_SECRET`, rejects mutations/subscriptions/introspection, and allows an optional `x-hasura-role` header via `HASURA_GRAPHQL_ROLE`.
- Introduce `src/L1/resume/.env.example` and remove client-exposed `NEXT_PUBLIC_HASURA_ADMIN_SECRET` file, and add `Security` notes to `README.md` describing how to use server-only env vars.
- Refactor query builders to return a `GraphQLRequest` object (`{ query, variables }`) in `lib/queries.ts` and stop composing query text via string interpolation; added fragments and typed queries for table lists, items, and search tag lists.
- Rework `BuilderCondition.ts` to build structured GraphQL boolean expressions instead of string concatenation, including equality and time-range condition builders and composed `_and`/`_or` groups.
- Update Apollo client in `lib/apolloClient.ts` to point to the new proxy endpoint `'/api/graphql'` instead of embedding a Hasura URI and secret.
- Update components and context to consume the new `GraphQLRequest` shape, including changes in `DimensionItemInfo*`, `Dropdown.container.tsx`, `RegionSelector.container.tsx`, `SearchItemSelector.tsx`, `SearchItems.tsx`, and `SearchItemsProvider.tsx` to pass `query` and `variables` into Apollo client calls and to skip queries correctly.
- Improve UI/debug output to show both the `query` and `variables` for GraphQL requests in the modal.

### Testing
- No automated test suite was added or modified for these changes.
- Manual static checks were performed by updating call sites to the new `GraphQLRequest` shape and ensuring TypeScript types aligned across `lib/queries.ts` and the consuming components. Please run `npm run build` or `npm run dev` to validate the app in your environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21922b0170832487b8cd540d1a4eeb)