### PR TITLE
[codex] Harden GraphQL proxy validation

### DIFF
--- a/src/L1/resume/app/api/graphql/route.ts
+++ b/src/L1/resume/app/api/graphql/route.ts
@@ -1,3 +1,5 @@
+import { isReadOnlyGraphQLRequest } from "@/lib/graphqlRequestValidation";
+
 const DEFAULT_HASURA_GRAPHQL_ENDPOINT = "https://assuring-phoenix-83.hasura.app/v1/graphql";
 
 export const dynamic = "force-dynamic";
@@ -8,45 +10,6 @@ function getHasuraConfig() {
     adminSecret: process.env.HASURA_ADMIN_SECRET,
     role: process.env.HASURA_GRAPHQL_ROLE,
   };
-}
-
-type GraphQLRequestBody = { query?: unknown };
-
-function hasQueryText(value: unknown): value is GraphQLRequestBody {
-  return typeof value === "object" && value !== null && "query" in value;
-}
-
-function getGraphQLOperationText(body: string) {
-  try {
-    const parsedBody = JSON.parse(body) as unknown;
-
-    if (Array.isArray(parsedBody)) {
-      return parsedBody
-        .filter(hasQueryText)
-        .map((requestBody) => requestBody.query)
-        .filter((query): query is string => typeof query === "string")
-        .join("\n");
-    }
-
-    if (hasQueryText(parsedBody) && typeof parsedBody.query === "string") {
-      return parsedBody.query;
-    }
-  } catch {
-    return body;
-  }
-
-  return body;
-}
-
-function isReadOnlyGraphQLRequest(body: string) {
-  const normalizedOperationText = getGraphQLOperationText(body).toLowerCase();
-
-  return ![
-    "mutation",
-    "subscription",
-    "__schema",
-    "__type",
-  ].some((blockedToken) => normalizedOperationText.includes(blockedToken));
 }
 
 export async function POST(request: Request) {

--- a/src/L1/resume/lib/BuilderCondition.test.ts
+++ b/src/L1/resume/lib/BuilderCondition.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { BuilderCondition } from "./BuilderCondition";
+
+describe("BuilderCondition", () => {
+  it("returns an empty expression when no filters are selected", () => {
+    expect(BuilderCondition(new Map())).toEqual({});
+  });
+
+  it("groups multiple equality values with _or", () => {
+    const items = new Map([["stat", new Set(["人口", "世帯"])]]); 
+
+    expect(BuilderCondition(items)).toEqual({
+      _and: [
+        {
+          _or: [
+            { STATLIST: { STATNAME: { _eq: "人口" } } },
+            { STATLIST: { STATNAME: { _eq: "世帯" } } },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("builds a bounded year range", () => {
+    const items = new Map([["time", new Set(["2020-2022"])]]);
+
+    expect(BuilderCondition(items)).toEqual({
+      _and: [{ TABLE_TIMEs: { YEAR: { _gte: 2020, _lte: 2022 } } }],
+    });
+  });
+
+  it("ignores invalid year ranges", () => {
+    const items = new Map([["time", new Set(["from-to"])]]);
+
+    expect(BuilderCondition(items)).toEqual({});
+  });
+});

--- a/src/L1/resume/lib/graphqlRequestValidation.test.ts
+++ b/src/L1/resume/lib/graphqlRequestValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isReadOnlyGraphQLRequest } from "./graphqlRequestValidation";
+
+describe("isReadOnlyGraphQLRequest", () => {
+  it("allows queries even when variables contain blocked words", () => {
+    const body = JSON.stringify({
+      query: "query Search($term: String!) { TABLELIST(where: { TITLE: { _like: $term } }) { TITLE } }",
+      variables: { term: "mutation" },
+    });
+
+    expect(isReadOnlyGraphQLRequest(body)).toBe(true);
+  });
+
+  it.each([
+    "mutation Update { update_TABLELIST { affected_rows } }",
+    "subscription Updates { TABLELIST { TITLE } }",
+    "query Introspection { __schema { queryType { name } } }",
+  ])("rejects blocked operations", (query) => {
+    expect(isReadOnlyGraphQLRequest(JSON.stringify({ query }))).toBe(false);
+  });
+
+  it("requires a valid JSON GraphQL request body", () => {
+    expect(isReadOnlyGraphQLRequest("query Search { TABLELIST { TITLE } }")).toBe(false);
+    expect(isReadOnlyGraphQLRequest(JSON.stringify({ variables: {} }))).toBe(false);
+  });
+
+  it("requires every batched request to be read-only", () => {
+    const readOnlyBatch = JSON.stringify([
+      { query: "query One { TABLELIST { TITLE } }" },
+      { query: "query Two { STATLIST { STATNAME } }" },
+    ]);
+    const mixedBatch = JSON.stringify([
+      { query: "query One { TABLELIST { TITLE } }" },
+      { query: "mutation Update { update_TABLELIST { affected_rows } }" },
+    ]);
+
+    expect(isReadOnlyGraphQLRequest(readOnlyBatch)).toBe(true);
+    expect(isReadOnlyGraphQLRequest(mixedBatch)).toBe(false);
+  });
+});

--- a/src/L1/resume/lib/graphqlRequestValidation.ts
+++ b/src/L1/resume/lib/graphqlRequestValidation.ts
@@ -1,0 +1,56 @@
+import { parse, visit } from "graphql";
+
+type GraphQLRequestBody = { query?: unknown };
+
+function hasQueryText(value: unknown): value is GraphQLRequestBody {
+  return typeof value === "object" && value !== null && "query" in value;
+}
+
+function getQueryTexts(body: string): string[] | undefined {
+  try {
+    const parsedBody = JSON.parse(body) as unknown;
+    const requests = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+
+    if (requests.length === 0 || !requests.every(hasQueryText)) {
+      return undefined;
+    }
+
+    const queries = requests.map((request) => request.query);
+
+    return queries.every((query): query is string => typeof query === "string")
+      ? queries
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isReadOnlyOperation(query: string) {
+  try {
+    const document = parse(query);
+    let isReadOnly = true;
+
+    visit(document, {
+      OperationDefinition(node) {
+        if (node.operation !== "query") {
+          isReadOnly = false;
+        }
+      },
+      Field(node) {
+        if (node.name.value === "__schema" || node.name.value === "__type") {
+          isReadOnly = false;
+        }
+      },
+    });
+
+    return isReadOnly;
+  } catch {
+    return false;
+  }
+}
+
+export function isReadOnlyGraphQLRequest(body: string) {
+  const queries = getQueryTexts(body);
+
+  return queries !== undefined && queries.every(isReadOnlyOperation);
+}

--- a/src/L1/resume/package.json
+++ b/src/L1/resume/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/L1/resume/vitest.unit.config.ts
+++ b/src/L1/resume/vitest.unit.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["lib/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Parse GraphQL operations with the `graphql` AST instead of matching blocked words in raw request text.
- Reject mutations, subscriptions, introspection, malformed request bodies, and mixed batches.
- Add unit tests for proxy validation and condition construction.
- Add `npm run test:unit` for Node-based Vitest tests.

## Validation
- `npm run test:unit` (10 tests)
- `tsc --noEmit`
- `next build`