### PR TITLE
[codex] Handle Hasura proxy failures

### DIFF
--- a/src/L1/resume/.env.example
+++ b/src/L1/resume/.env.example
@@ -1,5 +1,5 @@
 # Server-only Hasura credentials. Do not prefix these with NEXT_PUBLIC_.
 HASURA_GRAPHQL_ENDPOINT=https://assuring-phoenix-83.hasura.app/v1/graphql
 HASURA_ADMIN_SECRET=
-# Optional: execute Hasura requests as a restricted read-only role configured in Hasura.
+# Production: configure this role in Hasura with SELECT permissions only, then set it in Vercel.
 HASURA_GRAPHQL_ROLE=

--- a/src/L1/resume/README.md
+++ b/src/L1/resume/README.md
@@ -25,7 +25,7 @@ cp .env.example .env.local
 | --- | --- | --- | --- |
 | `HASURA_GRAPHQL_ENDPOINT` | No | Server only | Hasura GraphQL endpoint. Defaults to the current production endpoint when omitted. |
 | `HASURA_ADMIN_SECRET` | Yes | Server only | Secret sent from the Next.js API route to Hasura. |
-| `HASURA_GRAPHQL_ROLE` | No | Server only | Optional restricted Hasura role, for example a read-only role configured in Hasura permissions. |
+| `HASURA_GRAPHQL_ROLE` | Production | Server only | Restricted Hasura role with `SELECT` permissions only. |
 
 Do **not** prefix these variables with `NEXT_PUBLIC_`. Values with that prefix are exposed to browser JavaScript by Next.js.
 
@@ -33,7 +33,7 @@ Do **not** prefix these variables with `NEXT_PUBLIC_`. Values with that prefix a
 
 Browser code sends Apollo Client requests to `/api/graphql`. The API route forwards the request to Hasura and attaches `HASURA_ADMIN_SECRET` on the server, so the admin secret is never bundled into client-side JavaScript. The route also rejects mutations, subscriptions, and introspection requests before forwarding to Hasura.
 
-For defense in depth, configure a read-only Hasura role and set `HASURA_GRAPHQL_ROLE` so proxied requests do not execute with unrestricted admin permissions.
+For production, create a Hasura role with `SELECT` permissions only for the tables the application reads, then set its name as `HASURA_GRAPHQL_ROLE` in Vercel. Apply it to Production and, if preview deployments access shared data, Preview as well. The proxy forwards this role with every request so the admin secret does not grant browser requests unrestricted access.
 
 ## Scripts
 

--- a/src/L1/resume/app/api/graphql/route.test.ts
+++ b/src/L1/resume/app/api/graphql/route.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+const request = (query = "query Probe { TABLELIST(limit: 1) { TITLE } }") =>
+  new Request("https://example.test/api/graphql", {
+    method: "POST",
+    body: JSON.stringify({ query }),
+  });
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/graphql", () => {
+  it("forwards a read-only query with the restricted Hasura role", async () => {
+    vi.stubEnv("HASURA_ADMIN_SECRET", "test-secret");
+    vi.stubEnv("HASURA_GRAPHQL_ROLE", "resume_readonly");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { TABLELIST: [] } }), {
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-hasura-admin-secret": "test-secret",
+          "x-hasura-role": "resume_readonly",
+        }),
+      })
+    );
+  });
+
+  it("returns 502 when Hasura cannot be reached", async () => {
+    vi.stubEnv("HASURA_ADMIN_SECRET", "test-secret");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      errors: [{ message: "Unable to reach the GraphQL upstream service." }],
+    });
+  });
+
+  it("returns 504 when the upstream request times out", async () => {
+    vi.stubEnv("HASURA_ADMIN_SECRET", "test-secret");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("aborted", "AbortError"))
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(504);
+    await expect(response.json()).resolves.toEqual({
+      errors: [{ message: "The GraphQL upstream request timed out." }],
+    });
+  });
+});

--- a/src/L1/resume/app/api/graphql/route.ts
+++ b/src/L1/resume/app/api/graphql/route.ts
@@ -1,6 +1,7 @@
 import { isReadOnlyGraphQLRequest } from "@/lib/graphqlRequestValidation";
 
 const DEFAULT_HASURA_GRAPHQL_ENDPOINT = "https://assuring-phoenix-83.hasura.app/v1/graphql";
+const HASURA_REQUEST_TIMEOUT_MS = 10_000;
 
 export const dynamic = "force-dynamic";
 
@@ -40,17 +41,40 @@ export async function POST(request: Request) {
     headers["x-hasura-role"] = role;
   }
 
-  const hasuraResponse = await fetch(endpoint, {
-    method: "POST",
-    headers,
-    body,
-    cache: "no-store",
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), HASURA_REQUEST_TIMEOUT_MS);
 
-  return new Response(await hasuraResponse.text(), {
-    status: hasuraResponse.status,
-    headers: {
-      "content-type": hasuraResponse.headers.get("content-type") || "application/json",
-    },
-  });
+  try {
+    const hasuraResponse = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body,
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    return new Response(await hasuraResponse.text(), {
+      status: hasuraResponse.status,
+      headers: {
+        "content-type": hasuraResponse.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch (error) {
+    const timedOut = error instanceof DOMException && error.name === "AbortError";
+
+    return Response.json(
+      {
+        errors: [
+          {
+            message: timedOut
+              ? "The GraphQL upstream request timed out."
+              : "Unable to reach the GraphQL upstream service.",
+          },
+        ],
+      },
+      { status: timedOut ? 504 : 502 }
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/src/L1/resume/vitest.unit.config.ts
+++ b/src/L1/resume/vitest.unit.config.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": dirname,
+    },
+  },
   test: {
     environment: "node",
-    include: ["lib/**/*.test.ts"],
+    include: ["lib/**/*.test.ts", "app/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Add a 10-second timeout and safe 502/504 responses for Hasura proxy failures.
- Cover role forwarding and upstream failures with route tests.
- Document the production read-only Hasura role requirement.

## Validation
- `npm run test:unit` (13 tests)
- `tsc --noEmit`
- Vercel production build pending